### PR TITLE
Tried out ValueOption

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ version: "{build}" #until it gets updated at install
 configuration: Debug
 
 environment:
-  base_version: 0.10.0
+  base_version: 0.11.0
   github_deploy: false 
   is_prerelease: true
   package_version: $(BASE_VERSION)-alpha$(APPVEYOR_BUILD_NUMBER)

--- a/src/FSharp.Interop.NullOptAble/Experimental/Microsoft.fs
+++ b/src/FSharp.Interop.NullOptAble/Experimental/Microsoft.fs
@@ -1,0 +1,10 @@
+namespace FSharp.Interop.NullOptAble.Experimental
+
+[<StructuralEquality; StructuralComparison>]
+[<Struct>]
+[<CompiledName("FSharpValueOption`1")>]
+type ValueOption<'T> =
+    | VNone : 'T voption
+    | VSome : 'T -> 'T voption
+    member x.Value = match x with VSome x -> x | VNone -> raise (new System.InvalidOperationException("ValueOption.Value"))
+and 'T voption = ValueOption<'T>

--- a/src/FSharp.Interop.NullOptAble/Experimental/ValueOption.fs
+++ b/src/FSharp.Interop.NullOptAble/Experimental/ValueOption.fs
@@ -1,0 +1,16 @@
+namespace FSharp.Interop.NullOptAble.Experimental
+
+open System
+[<RequireQualifiedAccess>]
+module ValueOption =
+    let ofOption = function | Some x -> VSome x | None -> VNone
+    let ofNullable (value:'t Nullable) = if value.HasValue then VSome value.Value else VNone
+    let ofObj = function | null -> VNone | x -> VSome x
+    let ofTryTuple = function | (true, item) -> VSome(item) | (false, _) -> VNone
+    let bind binder = function | VNone -> VNone | VSome x -> binder x
+    let map mapping = function |  VNone -> VNone | VSome x -> VSome (mapping x)
+    let defaultValue value = function |  VNone -> value | VSome v -> v
+    let defaultWith defThunk = function | VNone -> defThunk () | VSome v -> v
+[<RequireQualifiedAccess>]
+module Option =
+    let ofValueOption = function | VSome x -> Some x | VNone -> None

--- a/src/FSharp.Interop.NullOptAble/FSharp.Interop.NullOptAble.fsproj
+++ b/src/FSharp.Interop.NullOptAble/FSharp.Interop.NullOptAble.fsproj
@@ -17,9 +17,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Experimental/Microsoft.fs" />
+    <Compile Include="Experimental/ValueOption.fs" />
     <Compile Include="Option.fsi" />
     <Compile Include="Option.fs" />
-    <Compile Include="TopLevelBuilders.fsi" />
+
     <Compile Include="TopLevelBuilders.fs" />
     <Compile Include="NullOptAble.fsi" />
     <Compile Include="NullOptAble.fs" />

--- a/src/FSharp.Interop.NullOptAble/NullOptAble.fs
+++ b/src/FSharp.Interop.NullOptAble/NullOptAble.fs
@@ -1,111 +1,177 @@
 ﻿namespace FSharp.Interop.NullOptAble
 
 open System
-
+open FSharp.Interop.NullOptAble.Experimental
+open FSharp.Interop.NullOptAble
 type NullOptAble =
         (* DefaultWith overloads *)
+        static member DefaultWith(a: 'a voption, b: 'a Lazy) =
+            a |> ValueOption.defaultWith b.Force
 
         static member DefaultWith(a: 'a option, b: 'a Lazy) =
-            a |> Option.defaultWith b.Force
+            a |> ValueOption.ofOption 
+              |> ValueOption.defaultWith b.Force
 
         static member DefaultWith(a: 'a Nullable, b: 'a Lazy) = 
-            a |> Option.ofNullable 
-              |> Option.defaultWith b.Force
+            a |> ValueOption.ofNullable 
+              |> ValueOption.defaultWith b.Force
 
         static member DefaultWith(a: 'a when 'a:null, b: 'a Lazy) =
-            a |> Option.ofObj 
-              |> Option.defaultWith b.Force
+            a |> ValueOption.ofObj 
+              |> ValueOption.defaultWith b.Force
 
         (* Map overloads *)
 
         static member Map(a: 'a option, f: 'a -> 'c) =
-            option { 
+            voption { 
+                let! a' = a 
+                return f a'
+            }
+
+        static member Map(a: 'a voption, f: 'a -> 'c) =
+            voption { 
                 let! a' = a 
                 return f a'
             }
 
         static member Map(a: 'a Nullable, f: 'a -> 'c) =
-            option { 
+            voption { 
                 let! a' = a 
                 return f a'
             }
 
         static member Map(a: 'a, f: 'a -> 'c) =
-            option { 
+            voption { 
                 let! a' = a 
                 return f a'
             }
 
         (* Map2 overloads *)
 
-        static member Map2((a: 'a option, b: 'b option), f: 'a -> 'b -> 'c) : 'c option
+        static member Map2((a: 'a option, b: 'b option), f: 'a -> 'b -> 'c) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return f a' b'
             }
 
-        static member Map2((a: 'a option, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c option
+        static member Map2((a: 'a option, b: 'b voption), f: 'a -> 'b -> 'c) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return f a' b'
             }
 
-        static member Map2((a: 'a option, b: 'b), f: 'a -> 'b -> 'c) : 'c option
+        static member Map2((a: 'a option, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return f a' b'
+            }
+
+        static member Map2((a: 'a option, b: 'b), f: 'a -> 'b -> 'c) : 'c voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return f a' b'
             }
 
-        static member Map2((a: 'a Nullable, b: 'b option), f: 'a -> 'b -> 'c) : 'c option
+        static member Map2((a: 'a voption, b: 'b option), f: 'a -> 'b -> 'c) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return f a' b'
             }
 
-        static member Map2((a: 'a Nullable, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c option
+        static member Map2((a: 'a voption, b: 'b voption), f: 'a -> 'b -> 'c) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return f a' b'
             }
 
-        static member Map2((a: 'a Nullable, b: 'b), f: 'a -> 'b -> 'c) : 'c option
+        static member Map2((a: 'a voption, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return f a' b'
+            }
+
+        static member Map2((a: 'a voption, b: 'b), f: 'a -> 'b -> 'c) : 'c voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return f a' b'
             }
 
-        static member Map2((a: 'a, b: 'b option), f: 'a -> 'b -> 'c) : 'c option
+        static member Map2((a: 'a Nullable, b: 'b option), f: 'a -> 'b -> 'c) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return f a' b'
+            }
+
+        static member Map2((a: 'a Nullable, b: 'b voption), f: 'a -> 'b -> 'c) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return f a' b'
+            }
+
+        static member Map2((a: 'a Nullable, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return f a' b'
+            }
+
+        static member Map2((a: 'a Nullable, b: 'b), f: 'a -> 'b -> 'c) : 'c voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return f a' b'
+            }
+
+        static member Map2((a: 'a, b: 'b option), f: 'a -> 'b -> 'c) : 'c voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return f a' b'
             }
 
-        static member Map2((a: 'a, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c option
+        static member Map2((a: 'a, b: 'b voption), f: 'a -> 'b -> 'c) : 'c voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return f a' b'
             }
 
-        static member Map2((a: 'a, b: 'b), f: 'a -> 'b -> 'c) : 'c option
+        static member Map2((a: 'a, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return f a' b'
+            }
+
+        static member Map2((a: 'a, b: 'b), f: 'a -> 'b -> 'c) : 'c voption
                 when 'a:null
                 and  'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return f a' b'
@@ -113,251 +179,587 @@ type NullOptAble =
 
         (* Map3 overloads *)
 
-        static member Map3((a: 'a option, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a option, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a option, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a option, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a option, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a option, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a option, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a option, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a option, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a option, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a option, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a option, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a option, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a option, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a option, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a option, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a option, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a option, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a option, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a option, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a option, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a option, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a option, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a option, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a option, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a Nullable, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a voption, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a Nullable, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a voption, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a Nullable, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a voption, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a voption, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a Nullable, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a voption, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a Nullable, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a voption, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a Nullable, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a voption, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a voption, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a Nullable, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a voption, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a voption, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a voption, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a voption, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a voption, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a Nullable, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a voption, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a Nullable, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a voption, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a voption, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a Nullable, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a Nullable, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return f a' b' c'
             }
 
-        static member Map3((a: 'a, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Map3((a: 'a, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null
+                and  'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return f a' b' c'
+            }
+
+        static member Map3((a: 'a, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'b:null 
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
@@ -367,280 +769,621 @@ type NullOptAble =
         (* bind overloads *)
         
         static member Bind(a: 'a option, f: 'a -> 'c option) = 
-            option {
+            voption {
+                let! a' = a
+                return! f a'
+            }
+        
+        static member Bind(a: 'a option, f: 'a -> 'c voption) = 
+            voption {
                 let! a' = a
                 return! f a'
             }
         
         static member Bind(a: 'a option, f: 'a -> 'c Nullable) = 
-            option {
+            voption {
                 let! a' = a
                 return! f a'
             }
         
         static member Bind(a: 'a option, f: 'a -> 'c) = 
-            option {
+            voption {
+                let! a' = a
+                return! f a'
+            }
+        
+        static member Bind(a: 'a voption, f: 'a -> 'c option) = 
+            voption {
+                let! a' = a
+                return! f a'
+            }
+        
+        static member Bind(a: 'a voption, f: 'a -> 'c voption) = 
+            voption {
+                let! a' = a
+                return! f a'
+            }
+        
+        static member Bind(a: 'a voption, f: 'a -> 'c Nullable) = 
+            voption {
+                let! a' = a
+                return! f a'
+            }
+        
+        static member Bind(a: 'a voption, f: 'a -> 'c) = 
+            voption {
                 let! a' = a
                 return! f a'
             }
         
         static member Bind(a: 'a Nullable, f: 'a -> 'c option) = 
-            option {
+            voption {
+                let! a' = a
+                return! f a'
+            }
+        
+        static member Bind(a: 'a Nullable, f: 'a -> 'c voption) = 
+            voption {
                 let! a' = a
                 return! f a'
             }
         
         static member Bind(a: 'a Nullable, f: 'a -> 'c Nullable) = 
-            option {
+            voption {
                 let! a' = a
                 return! f a'
             }
         
         static member Bind(a: 'a Nullable, f: 'a -> 'c) = 
-            option {
+            voption {
                 let! a' = a
                 return! f a'
             }
         
         static member Bind(a: 'a, f: 'a -> 'c option) = 
-            option {
+            voption {
+                let! a' = a
+                return! f a'
+            }
+        
+        static member Bind(a: 'a, f: 'a -> 'c voption) = 
+            voption {
                 let! a' = a
                 return! f a'
             }
         
         static member Bind(a: 'a, f: 'a -> 'c Nullable) = 
-            option {
+            voption {
                 let! a' = a
                 return! f a'
             }
         
         static member Bind(a: 'a, f: 'a -> 'c) = 
-            option {
+            voption {
                 let! a' = a
                 return! f a'
             }
 
         (* bind2 overloads *)
 
-        static member Bind2((a: 'a option, b: 'b option), f: 'a -> 'b -> 'c option) : 'c option
+        static member Bind2((a: 'a option, b: 'b option), f: 'a -> 'b -> 'c option) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a option, b: 'b option), f: 'a -> 'b -> 'c Nullable) : 'c option
+        static member Bind2((a: 'a option, b: 'b option), f: 'a -> 'b -> 'c voption) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a option, b: 'b option), f: 'a -> 'b -> 'c) : 'c option
+        static member Bind2((a: 'a option, b: 'b option), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a option, b: 'b option), f: 'a -> 'b -> 'c) : 'c voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a option, b: 'b Nullable), f: 'a -> 'b -> 'c option) : 'c option
+        static member Bind2((a: 'a option, b: 'b voption), f: 'a -> 'b -> 'c option) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a option, b: 'b Nullable), f: 'a -> 'b -> 'c Nullable) : 'c option
+        static member Bind2((a: 'a option, b: 'b voption), f: 'a -> 'b -> 'c voption) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a option, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c option
+        static member Bind2((a: 'a option, b: 'b voption), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a option, b: 'b voption), f: 'a -> 'b -> 'c) : 'c voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a option, b: 'b), f: 'a -> 'b -> 'c option) : 'c option
+        static member Bind2((a: 'a option, b: 'b Nullable), f: 'a -> 'b -> 'c option) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a option, b: 'b Nullable), f: 'a -> 'b -> 'c voption) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a option, b: 'b Nullable), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a option, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a option, b: 'b), f: 'a -> 'b -> 'c option) : 'c voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a option, b: 'b), f: 'a -> 'b -> 'c Nullable) : 'c option
+        static member Bind2((a: 'a option, b: 'b), f: 'a -> 'b -> 'c voption) : 'c voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a option, b: 'b), f: 'a -> 'b -> 'c) : 'c option
+        static member Bind2((a: 'a option, b: 'b), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a option, b: 'b), f: 'a -> 'b -> 'c) : 'c voption
                 when 'b:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a Nullable, b: 'b option), f: 'a -> 'b -> 'c option) : 'c option
+        static member Bind2((a: 'a voption, b: 'b option), f: 'a -> 'b -> 'c option) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a Nullable, b: 'b option), f: 'a -> 'b -> 'c Nullable) : 'c option
+        static member Bind2((a: 'a voption, b: 'b option), f: 'a -> 'b -> 'c voption) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a Nullable, b: 'b option), f: 'a -> 'b -> 'c) : 'c option
+        static member Bind2((a: 'a voption, b: 'b option), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a voption, b: 'b option), f: 'a -> 'b -> 'c) : 'c voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a Nullable, b: 'b Nullable), f: 'a -> 'b -> 'c option) : 'c option
+        static member Bind2((a: 'a voption, b: 'b voption), f: 'a -> 'b -> 'c option) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a Nullable, b: 'b Nullable), f: 'a -> 'b -> 'c Nullable) : 'c option
+        static member Bind2((a: 'a voption, b: 'b voption), f: 'a -> 'b -> 'c voption) : 'c voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a Nullable, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c option
+        static member Bind2((a: 'a voption, b: 'b voption), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a voption, b: 'b voption), f: 'a -> 'b -> 'c) : 'c voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a Nullable, b: 'b), f: 'a -> 'b -> 'c option) : 'c option
+        static member Bind2((a: 'a voption, b: 'b Nullable), f: 'a -> 'b -> 'c option) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a voption, b: 'b Nullable), f: 'a -> 'b -> 'c voption) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a voption, b: 'b Nullable), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a voption, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a voption, b: 'b), f: 'a -> 'b -> 'c option) : 'c voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a Nullable, b: 'b), f: 'a -> 'b -> 'c Nullable) : 'c option
+        static member Bind2((a: 'a voption, b: 'b), f: 'a -> 'b -> 'c voption) : 'c voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a Nullable, b: 'b), f: 'a -> 'b -> 'c) : 'c option
+        static member Bind2((a: 'a voption, b: 'b), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a voption, b: 'b), f: 'a -> 'b -> 'c) : 'c voption
                 when 'b:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a, b: 'b option), f: 'a -> 'b -> 'c option) : 'c option
+        static member Bind2((a: 'a Nullable, b: 'b option), f: 'a -> 'b -> 'c option) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b option), f: 'a -> 'b -> 'c voption) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b option), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b option), f: 'a -> 'b -> 'c) : 'c voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b voption), f: 'a -> 'b -> 'c option) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b voption), f: 'a -> 'b -> 'c voption) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b voption), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b voption), f: 'a -> 'b -> 'c) : 'c voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b Nullable), f: 'a -> 'b -> 'c option) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b Nullable), f: 'a -> 'b -> 'c voption) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b Nullable), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b), f: 'a -> 'b -> 'c option) : 'c voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b), f: 'a -> 'b -> 'c voption) : 'c voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a Nullable, b: 'b), f: 'a -> 'b -> 'c) : 'c voption
+                when 'b:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a, b: 'b option), f: 'a -> 'b -> 'c option) : 'c voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a, b: 'b option), f: 'a -> 'b -> 'c Nullable) : 'c option
+        static member Bind2((a: 'a, b: 'b option), f: 'a -> 'b -> 'c voption) : 'c voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a, b: 'b option), f: 'a -> 'b -> 'c) : 'c option
+        static member Bind2((a: 'a, b: 'b option), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a, b: 'b option), f: 'a -> 'b -> 'c) : 'c voption
                 when 'a:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a, b: 'b Nullable), f: 'a -> 'b -> 'c option) : 'c option
+        static member Bind2((a: 'a, b: 'b voption), f: 'a -> 'b -> 'c option) : 'c voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a, b: 'b Nullable), f: 'a -> 'b -> 'c Nullable) : 'c option
+        static member Bind2((a: 'a, b: 'b voption), f: 'a -> 'b -> 'c voption) : 'c voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c option
+        static member Bind2((a: 'a, b: 'b voption), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a, b: 'b voption), f: 'a -> 'b -> 'c) : 'c voption
                 when 'a:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a, b: 'b), f: 'a -> 'b -> 'c option) : 'c option
+        static member Bind2((a: 'a, b: 'b Nullable), f: 'a -> 'b -> 'c option) : 'c voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a, b: 'b Nullable), f: 'a -> 'b -> 'c voption) : 'c voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a, b: 'b Nullable), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a, b: 'b Nullable), f: 'a -> 'b -> 'c) : 'c voption
+                when 'a:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a, b: 'b), f: 'a -> 'b -> 'c option) : 'c voption
                 when 'a:null
                 and  'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a, b: 'b), f: 'a -> 'b -> 'c Nullable) : 'c option
+        static member Bind2((a: 'a, b: 'b), f: 'a -> 'b -> 'c voption) : 'c voption
                 when 'a:null
                 and  'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
             } 
 
-        static member Bind2((a: 'a, b: 'b), f: 'a -> 'b -> 'c) : 'c option
+        static member Bind2((a: 'a, b: 'b), f: 'a -> 'b -> 'c Nullable) : 'c voption
+                when 'a:null
+                and  'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                return! f a' b'
+            } 
+
+        static member Bind2((a: 'a, b: 'b), f: 'a -> 'b -> 'c) : 'c voption
                 when 'a:null
                 and  'b:null 
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 return! f a' b'
@@ -648,772 +1391,2385 @@ type NullOptAble =
 
         (* bind3 overloads *)
 
-        static member Bind3((a: 'a option, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a option, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a option, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a option, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a option, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a option, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a option, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a option, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a option, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a option, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'c:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'c:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'c:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a option, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a option, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a option, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a option, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a option, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a option, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'b:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a option, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'b:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a option, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a option, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a option, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null
                 and  'c:null 
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'c:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'c:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'c:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a voption, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a voption, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a voption, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a voption, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a voption, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a voption, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'b:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a voption, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'b:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a Nullable, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a voption, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a voption, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'b:null
                 and  'c:null 
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'c:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'c:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'c:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'b:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'b:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'b:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a Nullable, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'b:null
+                and  'c:null 
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b option, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b option, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b option, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'a:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'a:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b option, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'c:null 
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b voption, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'a:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b voption, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b voption, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'a:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'a:null
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b voption, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'c:null 
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'a:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'a:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b Nullable, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null
+                and  'c:null 
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'a:null
                 and  'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'a:null
                 and  'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null
+                and  'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b, c: 'c option), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'b:null 
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'a:null
                 and  'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'a:null
                 and  'b:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null
+                and  'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b, c: 'c voption), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'b:null 
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd option
+        static member Bind3((a: 'a, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
+                when 'a:null
+                and  'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
+                when 'a:null
+                and  'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null
+                and  'b:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b, c: 'c Nullable), f: 'a -> 'b -> 'c -> 'd) : 'd voption
+                when 'a:null
+                and  'b:null 
+                and  'd:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd option) : 'd voption
                 when 'a:null
                 and  'b:null 
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd option
+        static member Bind3((a: 'a, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd voption) : 'd voption
                 when 'a:null
                 and  'b:null 
                 and  'c:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c
                 return! f a' b' c'
             } 
 
-        static member Bind3((a: 'a, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd option
+        static member Bind3((a: 'a, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd Nullable) : 'd voption
+                when 'a:null
+                and  'b:null 
+                and  'c:null =
+            voption { 
+                let! a' = a 
+                let! b' = b
+                let! c' = c
+                return! f a' b' c'
+            } 
+
+        static member Bind3((a: 'a, b: 'b, c: 'c), f: 'a -> 'b -> 'c -> 'd) : 'd voption
                 when 'a:null
                 and  'b:null
                 and  'c:null 
                 and  'd:null =
-            option { 
+            voption { 
                 let! a' = a 
                 let! b' = b
                 let! c' = c

--- a/src/FSharp.Interop.NullOptAble/NullOptAble.fsi
+++ b/src/FSharp.Interop.NullOptAble/NullOptAble.fsi
@@ -1,14 +1,15 @@
 ﻿namespace FSharp.Interop.NullOptAble
 
 ///**Description**
-///
-/// Overloads used as the basis for the operators
-///
+/// Overloads used as the basis for operators
+open FSharp.Interop.NullOptAble.Experimental
 type NullOptAble =
     class
         (* DefaultWith overloads *)
 
         static member DefaultWith : 'a option * System.Lazy<'a> -> 'a
+        
+        static member DefaultWith : 'a voption * System.Lazy<'a> -> 'a
 
         static member DefaultWith : System.Nullable<'a> * System.Lazy<'a> -> 'a
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
@@ -17,679 +18,1631 @@ type NullOptAble =
 
         (* Map overloads *)
 
-        static member Map : 'a option * ('a -> 'c) -> 'c option
+        static member Map : 'a option * ('a -> 'c) -> 'c voption
                
 
-        static member Map : System.Nullable<'a> * ('a -> 'c) -> 'c option
+        static member Map : 'a voption * ('a -> 'c) -> 'c voption
+               
+
+        static member Map : System.Nullable<'a> * ('a -> 'c) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
 
-        static member Map : 'a * ('a -> 'c) -> 'c option
+        static member Map : 'a * ('a -> 'c) -> 'c voption
                 when 'a : null
 
         (* Map2 overloads *)
 
-        static member Map2 : ('a option * 'b option) * ('a -> 'b -> 'c) -> 'c option
+        static member Map2 : ('a option * 'b option) * ('a -> 'b -> 'c) -> 'c voption
                
 
-        static member Map2 : ('a option * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c option
+        static member Map2 : ('a option * 'b voption) * ('a -> 'b -> 'c) -> 'c voption
+               
+
+        static member Map2 : ('a option * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Map2 : ('a option * 'b) * ('a -> 'b -> 'c) -> 'c option
+        static member Map2 : ('a option * 'b) * ('a -> 'b -> 'c) -> 'c voption
                 when 'b : null
 
-        static member Map2 : (System.Nullable<'a> * 'b option) * ('a -> 'b -> 'c) -> 'c option
+        static member Map2 : ('a voption * 'b option) * ('a -> 'b -> 'c) -> 'c voption
+               
+
+        static member Map2 : ('a voption * 'b voption) * ('a -> 'b -> 'c) -> 'c voption
+               
+
+        static member Map2 : ('a voption * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Map2 : ('a voption * 'b) * ('a -> 'b -> 'c) -> 'c voption
+                when 'b : null
+
+        static member Map2 : (System.Nullable<'a> * 'b option) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
 
-        static member Map2 : (System.Nullable<'a> * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c option
+        static member Map2 : (System.Nullable<'a> * 'b voption) * ('a -> 'b -> 'c) -> 'c voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Map2 : (System.Nullable<'a> * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Map2 : (System.Nullable<'a> * 'b) * ('a -> 'b -> 'c) -> 'c option
+        static member Map2 : (System.Nullable<'a> * 'b) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null
 
-        static member Map2 : ('a * 'b option) * ('a -> 'b -> 'c) -> 'c option
+        static member Map2 : ('a * 'b option) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : null
 
-        static member Map2 : ('a * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c option
+        static member Map2 : ('a * 'b voption) * ('a -> 'b -> 'c) -> 'c voption
+                when 'a : null
+
+        static member Map2 : ('a * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : null
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Map2 : ('a * 'b) * ('a -> 'b -> 'c) -> 'c option
+        static member Map2 : ('a * 'b) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : null
                 and  'b : null
 
         (* Map3 overloads *)
 
-        static member Map3 : ('a option * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a option * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                
 
-        static member Map3 : ('a option * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a option * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+               
+
+        static member Map3 : ('a option * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Map3 : ('a option * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a option * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'c : null
 
-        static member Map3 : ('a option * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a option * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+               
+
+        static member Map3 : ('a option * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+               
+
+        static member Map3 : ('a option * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Map3 : ('a option * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : null
+
+        static member Map3 : ('a option * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Map3 : ('a option * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a option * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Map3 : ('a option * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Map3 : ('a option * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a option * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : null
 
-        static member Map3 : ('a option * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a option * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : null
 
-        static member Map3 : ('a option * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a option * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : null
+
+        static member Map3 : ('a option * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : null
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Map3 : ('a option * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a option * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : null
                 and  'c : null
 
-        static member Map3 : (System.Nullable<'a> * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a voption * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+               
+
+        static member Map3 : ('a voption * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+               
+
+        static member Map3 : ('a voption * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Map3 : ('a voption * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : null
+
+        static member Map3 : ('a voption * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+               
+
+        static member Map3 : ('a voption * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+               
+
+        static member Map3 : ('a voption * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Map3 : ('a voption * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : null
+
+        static member Map3 : ('a voption * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Map3 : ('a voption * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Map3 : ('a voption * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Map3 : ('a voption * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : null
+
+        static member Map3 : ('a voption * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : null
+
+        static member Map3 : ('a voption * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : null
+
+        static member Map3 : ('a voption * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Map3 : ('a voption * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : null
+                and  'c : null
+
+        static member Map3 : (System.Nullable<'a> * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
 
-        static member Map3 : (System.Nullable<'a> * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : (System.Nullable<'a> * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Map3 : (System.Nullable<'a> * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Map3 : (System.Nullable<'a> * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : (System.Nullable<'a> * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : null
 
-        static member Map3 : (System.Nullable<'a> * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : (System.Nullable<'a> * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Map3 : (System.Nullable<'a> * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Map3 : (System.Nullable<'a> * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Map3 : (System.Nullable<'a> * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : null
+
+        static member Map3 : (System.Nullable<'a> * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Map3 : (System.Nullable<'a> * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : (System.Nullable<'a> * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Map3 : (System.Nullable<'a> * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Map3 : (System.Nullable<'a> * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : (System.Nullable<'a> * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'c : null
 
-        static member Map3 : (System.Nullable<'a> * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : (System.Nullable<'a> * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null
 
-        static member Map3 : (System.Nullable<'a> * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : (System.Nullable<'a> * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null
+
+        static member Map3 : (System.Nullable<'a> * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Map3 : (System.Nullable<'a> * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : (System.Nullable<'a> * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null 
                 and  'c : null
 
-        static member Map3 : ('a * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
 
-        static member Map3 : ('a * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+
+        static member Map3 : ('a * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Map3 : ('a * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
                 and  'c : null
 
-        static member Map3 : ('a * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+
+        static member Map3 : ('a * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+
+        static member Map3 : ('a * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Map3 : ('a * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'c : null
+
+        static member Map3 : ('a * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Map3 : ('a * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Map3 : ('a * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Map3 : ('a * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'c : null
 
-        static member Map3 : ('a * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
                 and  'b : null
 
-        static member Map3 : ('a * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'b : null
+
+        static member Map3 : ('a * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
                 and  'b : null 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Map3 : ('a * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Map3 : ('a * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
                 and  'b : null 
                 and  'c : null
 
         (* bind overloads *)
 
-        static member Bind : a:'a option * ('a -> 'c option) -> 'c option
+        static member Bind : a:'a option * ('a -> 'c option) -> 'c voption
                
 
-        static member Bind : a:'a option * ('a -> System.Nullable<'c>) -> 'c option
+        static member Bind : a:'a option * ('a -> 'c voption) -> 'c voption
+               
+
+        static member Bind : a:'a option * ('a -> System.Nullable<'c>) -> 'c voption
                 when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind : a:'a option * ('a -> 'c) -> 'c option
+        static member Bind : a:'a option * ('a -> 'c) -> 'c voption
                 when 'c : null
 
-        static member Bind : a:System.Nullable<'a> * ('a -> 'c option) -> 'c option
+        static member Bind : a:'a voption * ('a -> 'c option) -> 'c voption
+               
+
+        static member Bind : a:'a voption * ('a -> 'c voption) -> 'c voption
+               
+
+        static member Bind : a:'a voption * ('a -> System.Nullable<'c>) -> 'c voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind : a:'a voption * ('a -> 'c) -> 'c voption
+                when 'c : null
+
+        static member Bind : a:System.Nullable<'a> * ('a -> 'c option) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
 
-        static member Bind : a:System.Nullable<'a> * ('a -> System.Nullable<'c>) -> 'c option
+        static member Bind : a:System.Nullable<'a> * ('a -> 'c voption) -> 'c voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind : a:System.Nullable<'a> * ('a -> System.Nullable<'c>) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind : a:System.Nullable<'a> * ('a -> 'c) -> 'c option
+        static member Bind : a:System.Nullable<'a> * ('a -> 'c) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : null
 
-        static member Bind : a:'a * ('a -> 'c option) -> 'c option
+        static member Bind : a:'a * ('a -> 'c option) -> 'c voption
                 when 'a : null
 
-        static member Bind : a:'a * ('a -> System.Nullable<'c>) -> 'c option
+        static member Bind : a:'a * ('a -> 'c voption) -> 'c voption
+                when 'a : null
+
+        static member Bind : a:'a * ('a -> System.Nullable<'c>) -> 'c voption
                 when 'a : null
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind : a:'a * ('a -> 'c) -> 'c option
+        static member Bind : a:'a * ('a -> 'c) -> 'c voption
                 when 'a : null
                 and  'c : null
 
         (* bind2 overloads *)
 
-        static member Bind2 : ('a option * 'b option) * ('a -> 'b -> 'c option) -> 'c option
+        static member Bind2 : ('a option * 'b option) * ('a -> 'b -> 'c option) -> 'c voption
                
 
-        static member Bind2 : ('a option * 'b option) * ('a -> 'b -> System.Nullable<'c>) -> 'c option
+        static member Bind2 : ('a option * 'b option) * ('a -> 'b -> 'c voption) -> 'c voption
+               
+
+        static member Bind2 : ('a option * 'b option) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
                 when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind2 : ('a option * 'b option) * ('a -> 'b -> 'c) -> 'c option
+        static member Bind2 : ('a option * 'b option) * ('a -> 'b -> 'c) -> 'c voption
                 when 'c : null
 
-        static member Bind2 : ('a option * System.Nullable<'b>) * ('a -> 'b -> 'c option) -> 'c option
+        static member Bind2 : ('a option * 'b voption) * ('a -> 'b -> 'c option) -> 'c voption
+               
+
+        static member Bind2 : ('a option * 'b voption) * ('a -> 'b -> 'c voption) -> 'c voption
+               
+
+        static member Bind2 : ('a option * 'b voption) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind2 : ('a option * 'b voption) * ('a -> 'b -> 'c) -> 'c voption
+                when 'c : null
+
+        static member Bind2 : ('a option * System.Nullable<'b>) * ('a -> 'b -> 'c option) -> 'c voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Bind2 : ('a option * System.Nullable<'b>) * ('a -> 'b -> System.Nullable<'c>) -> 'c option
+        static member Bind2 : ('a option * System.Nullable<'b>) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind2 : ('a option * System.Nullable<'b>) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind2 : ('a option * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c option
+        static member Bind2 : ('a option * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : null
 
-        static member Bind2 : ('a option * 'b) * ('a -> 'b -> 'c option) -> 'c option
+        static member Bind2 : ('a option * 'b) * ('a -> 'b -> 'c option) -> 'c voption
                 when 'b : null
 
-        static member Bind2 : ('a option * 'b) * ('a -> 'b -> System.Nullable<'c>) -> 'c option
+        static member Bind2 : ('a option * 'b) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'b : null
+
+        static member Bind2 : ('a option * 'b) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
                 when 'b : null
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind2 : ('a option * 'b) * ('a -> 'b -> 'c) -> 'c option
+        static member Bind2 : ('a option * 'b) * ('a -> 'b -> 'c) -> 'c voption
                 when 'b : null
                 and  'c : null
 
-        static member Bind2 : (System.Nullable<'a> * 'b option) * ('a -> 'b -> 'c option) -> 'c option
+        static member Bind2 : ('a voption * 'b option) * ('a -> 'b -> 'c option) -> 'c voption
+               
+
+        static member Bind2 : ('a voption * 'b option) * ('a -> 'b -> 'c voption) -> 'c voption
+               
+
+        static member Bind2 : ('a voption * 'b option) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind2 : ('a voption * 'b option) * ('a -> 'b -> 'c) -> 'c voption
+                when 'c : null
+
+        static member Bind2 : ('a voption * 'b voption) * ('a -> 'b -> 'c option) -> 'c voption
+               
+
+        static member Bind2 : ('a voption * 'b voption) * ('a -> 'b -> 'c voption) -> 'c voption
+               
+
+        static member Bind2 : ('a voption * 'b voption) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind2 : ('a voption * 'b voption) * ('a -> 'b -> 'c) -> 'c voption
+                when 'c : null
+
+        static member Bind2 : ('a voption * System.Nullable<'b>) * ('a -> 'b -> 'c option) -> 'c voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind2 : ('a voption * System.Nullable<'b>) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind2 : ('a voption * System.Nullable<'b>) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind2 : ('a voption * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : null
+
+        static member Bind2 : ('a voption * 'b) * ('a -> 'b -> 'c option) -> 'c voption
+                when 'b : null
+
+        static member Bind2 : ('a voption * 'b) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'b : null
+
+        static member Bind2 : ('a voption * 'b) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
+                when 'b : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind2 : ('a voption * 'b) * ('a -> 'b -> 'c) -> 'c voption
+                when 'b : null
+                and  'c : null
+
+        static member Bind2 : (System.Nullable<'a> * 'b option) * ('a -> 'b -> 'c option) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
 
-        static member Bind2 : (System.Nullable<'a> * 'b option) * ('a -> 'b -> System.Nullable<'c>) -> 'c option
+        static member Bind2 : (System.Nullable<'a> * 'b option) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind2 : (System.Nullable<'a> * 'b option) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind2 : (System.Nullable<'a> * 'b option) * ('a -> 'b -> 'c) -> 'c option
+        static member Bind2 : (System.Nullable<'a> * 'b option) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : null
 
-        static member Bind2 : (System.Nullable<'a> * System.Nullable<'b>) * ('a -> 'b -> 'c option) -> 'c option
+        static member Bind2 : (System.Nullable<'a> * 'b voption) * ('a -> 'b -> 'c option) -> 'c voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind2 : (System.Nullable<'a> * 'b voption) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind2 : (System.Nullable<'a> * 'b voption) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind2 : (System.Nullable<'a> * 'b voption) * ('a -> 'b -> 'c) -> 'c voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : null
+
+        static member Bind2 : (System.Nullable<'a> * System.Nullable<'b>) * ('a -> 'b -> 'c option) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Bind2 : (System.Nullable<'a> * System.Nullable<'b>) * ('a -> 'b -> System.Nullable<'c>) -> 'c option
+        static member Bind2 : (System.Nullable<'a> * System.Nullable<'b>) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind2 : (System.Nullable<'a> * System.Nullable<'b>) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind2 : (System.Nullable<'a> * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c option
+        static member Bind2 : (System.Nullable<'a> * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'c : null
 
-        static member Bind2 : (System.Nullable<'a> * 'b) * ('a -> 'b -> 'c option) -> 'c option
+        static member Bind2 : (System.Nullable<'a> * 'b) * ('a -> 'b -> 'c option) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null
 
-        static member Bind2 : (System.Nullable<'a> * 'b) * ('a -> 'b -> System.Nullable<'c>) -> 'c option
+        static member Bind2 : (System.Nullable<'a> * 'b) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null
+
+        static member Bind2 : (System.Nullable<'a> * 'b) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind2 : (System.Nullable<'a> * 'b) * ('a -> 'b -> 'c) -> 'c option
+        static member Bind2 : (System.Nullable<'a> * 'b) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null 
                 and  'c : null
 
-        static member Bind2 : ('a * 'b option) * ('a -> 'b -> 'c option) -> 'c option
+        static member Bind2 : ('a * 'b option) * ('a -> 'b -> 'c option) -> 'c voption
                 when 'a : null
 
-        static member Bind2 : ('a * 'b option) * ('a -> 'b -> System.Nullable<'c>) -> 'c option
+        static member Bind2 : ('a * 'b option) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'a : null
+
+        static member Bind2 : ('a * 'b option) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
                 when 'a : null
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind2 : ('a * 'b option) * ('a -> 'b -> 'c) -> 'c option
+        static member Bind2 : ('a * 'b option) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : null
                 and  'c : null
 
-        static member Bind2 : ('a * System.Nullable<'b>) * ('a -> 'b -> 'c option) -> 'c option
+        static member Bind2 : ('a * 'b voption) * ('a -> 'b -> 'c option) -> 'c voption
+                when 'a : null
+
+        static member Bind2 : ('a * 'b voption) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'a : null
+
+        static member Bind2 : ('a * 'b voption) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
+                when 'a : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind2 : ('a * 'b voption) * ('a -> 'b -> 'c) -> 'c voption
+                when 'a : null
+                and  'c : null
+
+        static member Bind2 : ('a * System.Nullable<'b>) * ('a -> 'b -> 'c option) -> 'c voption
                 when 'a : null
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Bind2 : ('a * System.Nullable<'b>) * ('a -> 'b -> System.Nullable<'c>) -> 'c option
+        static member Bind2 : ('a * System.Nullable<'b>) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind2 : ('a * System.Nullable<'b>) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
                 when 'a : null
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind2 : ('a * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c option
+        static member Bind2 : ('a * System.Nullable<'b>) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : null
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'c : null
 
-        static member Bind2 : ('a * 'b) * ('a -> 'b -> 'c option) -> 'c option
+        static member Bind2 : ('a * 'b) * ('a -> 'b -> 'c option) -> 'c voption
                 when 'a : null
                 and  'b : null
 
-        static member Bind2 : ('a * 'b) * ('a -> 'b -> System.Nullable<'c>) -> 'c option
+        static member Bind2 : ('a * 'b) * ('a -> 'b -> 'c voption) -> 'c voption
+                when 'a : null
+                and  'b : null
+
+        static member Bind2 : ('a * 'b) * ('a -> 'b -> System.Nullable<'c>) -> 'c voption
                 when 'a : null
                 and  'b : null 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind2 : ('a * 'b) * ('a -> 'b -> 'c) -> 'c option
+        static member Bind2 : ('a * 'b) * ('a -> 'b -> 'c) -> 'c voption
                 when 'a : null
                 and  'b : null 
                 and  'c : null
 
         (* bind3 overloads *)
 
-        static member Bind3 : ('a option * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a option * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                
 
-        static member Bind3 : ('a option * 'b option * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : ('a option * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+               
+
+        static member Bind3 : ('a option * 'b option * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a option * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a option * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'd : null
 
-        static member Bind3 : ('a option * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a option * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+               
+
+        static member Bind3 : ('a option * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+               
+
+        static member Bind3 : ('a option * 'b option * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a option * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'd : null
+
+        static member Bind3 : ('a option * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind3 : ('a option * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : ('a option * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a option * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a option * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a option * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
                 and  'd : null
 
-        static member Bind3 : ('a option * 'b option * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a option * 'b option * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'c : null
 
-        static member Bind3 : ('a option * 'b option * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : ('a option * 'b option * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'c : null
+
+        static member Bind3 : ('a option * 'b option * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'c : null
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a option * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a option * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'c : null
                 and  'd : null
 
-        static member Bind3 : ('a option * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a option * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+               
+
+        static member Bind3 : ('a option * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+               
+
+        static member Bind3 : ('a option * 'b voption * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a option * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'd : null
+
+        static member Bind3 : ('a option * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+               
+
+        static member Bind3 : ('a option * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+               
+
+        static member Bind3 : ('a option * 'b voption * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a option * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'd : null
+
+        static member Bind3 : ('a option * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a option * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a option * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a option * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+                and  'd : null
+
+        static member Bind3 : ('a option * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'c : null
+
+        static member Bind3 : ('a option * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'c : null
+
+        static member Bind3 : ('a option * 'b voption * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'c : null
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a option * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : null
+                and  'd : null
+
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Bind3 : ('a option * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a option * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'd : null
 
-        static member Bind3 : ('a option * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'd : null
+
+        static member Bind3 : ('a option * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind3 : ('a option * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : ('a option * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a option * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a option * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a option * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
                 and  'd : null
 
-        static member Bind3 : ('a option * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : null
 
-        static member Bind3 : ('a option * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : null
+
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : null 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a option * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a option * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : null 
                 and  'd : null
 
-        static member Bind3 : ('a option * 'b * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a option * 'b * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'b : null
 
-        static member Bind3 : ('a option * 'b * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : ('a option * 'b * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : null
+
+        static member Bind3 : ('a option * 'b * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'b : null
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a option * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a option * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : null
                 and  'd : null
 
-        static member Bind3 : ('a option * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a option * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'b : null
+
+        static member Bind3 : ('a option * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : null
+
+        static member Bind3 : ('a option * 'b * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'b : null
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a option * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : null
+                and  'd : null
+
+        static member Bind3 : ('a option * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'b : null
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind3 : ('a option * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : ('a option * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a option * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'b : null
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a option * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a option * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : null
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
                 and  'd : null
 
-        static member Bind3 : ('a option * 'b * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a option * 'b * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'b : null
                 and  'c : null
 
-        static member Bind3 : ('a option * 'b * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : ('a option * 'b * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : null
+                and  'c : null
+
+        static member Bind3 : ('a option * 'b * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'b : null
                 and  'c : null 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a option * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a option * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'b : null
                 and  'c : null 
                 and  'd : null
 
-        static member Bind3 : (System.Nullable<'a> * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a voption * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+               
+
+        static member Bind3 : ('a voption * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+               
+
+        static member Bind3 : ('a voption * 'b option * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'd : null
+
+        static member Bind3 : ('a voption * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+               
+
+        static member Bind3 : ('a voption * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+               
+
+        static member Bind3 : ('a voption * 'b option * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'd : null
+
+        static member Bind3 : ('a voption * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+                and  'd : null
+
+        static member Bind3 : ('a voption * 'b option * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'c : null
+
+        static member Bind3 : ('a voption * 'b option * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'c : null
+
+        static member Bind3 : ('a voption * 'b option * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'c : null
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : null
+                and  'd : null
+
+        static member Bind3 : ('a voption * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+               
+
+        static member Bind3 : ('a voption * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+               
+
+        static member Bind3 : ('a voption * 'b voption * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'd : null
+
+        static member Bind3 : ('a voption * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+               
+
+        static member Bind3 : ('a voption * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+               
+
+        static member Bind3 : ('a voption * 'b voption * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'd : null
+
+        static member Bind3 : ('a voption * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+                and  'd : null
+
+        static member Bind3 : ('a voption * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'c : null
+
+        static member Bind3 : ('a voption * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'c : null
+
+        static member Bind3 : ('a voption * 'b voption * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'c : null
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'c : null
+                and  'd : null
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'd : null
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'd : null
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : null
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : null
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : null
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : null 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : null 
+                and  'd : null
+
+        static member Bind3 : ('a voption * 'b * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'b : null
+
+        static member Bind3 : ('a voption * 'b * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : null
+
+        static member Bind3 : ('a voption * 'b * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'b : null
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : null
+                and  'd : null
+
+        static member Bind3 : ('a voption * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'b : null
+
+        static member Bind3 : ('a voption * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : null
+
+        static member Bind3 : ('a voption * 'b * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'b : null
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : null
+                and  'd : null
+
+        static member Bind3 : ('a voption * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'b : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'b : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : null
+
+        static member Bind3 : ('a voption * 'b * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'b : null
+                and  'c : null
+
+        static member Bind3 : ('a voption * 'b * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'b : null
+                and  'c : null
+
+        static member Bind3 : ('a voption * 'b * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'b : null
+                and  'c : null 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a voption * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'b : null
+                and  'c : null 
+                and  'd : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * 'b option * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'd : null
 
-        static member Bind3 : (System.Nullable<'a> * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'd : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
                 and  'd : null
 
-        static member Bind3 : (System.Nullable<'a> * 'b option * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : null
 
-        static member Bind3 : (System.Nullable<'a> * 'b option * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : null 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'c : null 
                 and  'd : null
 
-        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'd : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'd : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : null 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'c : null 
+                and  'd : null
+
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'd : null
 
-        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'd : null
+
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
                 and  'd : null
 
-        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
                 and  'c : null
 
-        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'c : null
+
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : null 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
                 and  'c : null 
                 and  'd : null
 
-        static member Bind3 : (System.Nullable<'a> * 'b * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null
 
-        static member Bind3 : (System.Nullable<'a> * 'b * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null 
                 and  'd : null
 
-        static member Bind3 : (System.Nullable<'a> * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null 
+                and  'd : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
                 and  'b : null 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind3 : (System.Nullable<'a> * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
                 when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
-                and  'b : null
-                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
-                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
-
-        static member Bind3 : (System.Nullable<'a> * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
-                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
-                and  'b : null
-                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
-                and  'd : null
-
-        static member Bind3 : (System.Nullable<'a> * 'b * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd option
-                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
-                and  'b : null 
-                and  'c : null
-
-        static member Bind3 : (System.Nullable<'a> * 'b * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
-                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
-                and  'b : null
-                and  'c : null 
-                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
-
-        static member Bind3 : (System.Nullable<'a> * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
-                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
-                and  'b : null
-                and  'c : null 
-                and  'd : null
-
-        static member Bind3 : ('a * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd option
-                when 'a : null
-
-        static member Bind3 : ('a * 'b option * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
-                when 'a : null
-                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
-
-        static member Bind3 : ('a * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
-                when 'a : null
-                and  'd : null
-
-        static member Bind3 : ('a * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd option
-                when 'a : null
-                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
-
-        static member Bind3 : ('a * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
-                when 'a : null
-                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
-                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
-
-        static member Bind3 : ('a * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
-                when 'a : null
-                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
-                and  'd : null
-
-        static member Bind3 : ('a * 'b option * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd option
-                when 'a : null
-                and  'c : null
-
-        static member Bind3 : ('a * 'b option * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
-                when 'a : null
-                and  'c : null 
-                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
-
-        static member Bind3 : ('a * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
-                when 'a : null
-                and  'c : null 
-                and  'd : null
-
-        static member Bind3 : ('a * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd option
-                when 'a : null
-                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
-
-        static member Bind3 : ('a * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
-                when 'a : null
-                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
-                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
-
-        static member Bind3 : ('a * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
-                when 'a : null
-                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
-                and  'd : null
-
-        static member Bind3 : ('a * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd option
-                when 'a : null
-                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
-                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
-
-        static member Bind3 : ('a * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
-                when 'a : null
-                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
-                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
-                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
-
-        static member Bind3 : ('a * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
-                when 'a : null
-                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
-                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
-                and  'd : null
-
-        static member Bind3 : ('a * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd option
-                when 'a : null
-                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
-                and  'c : null
-
-        static member Bind3 : ('a * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
-                when 'a : null
-                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
-                and  'c : null 
-                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
-
-        static member Bind3 : ('a * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
-                when 'a : null
-                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
-                and  'c : null 
-                and  'd : null
-
-        static member Bind3 : ('a * 'b * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd option
-                when 'a : null
-                and  'b : null
-
-        static member Bind3 : ('a * 'b * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
-                when 'a : null
-                and  'b : null 
-                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
-
-        static member Bind3 : ('a * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd option
-                when 'a : null
-                and  'b : null 
-                and  'd : null
-
-        static member Bind3 : ('a * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd option
-                when 'a : null
                 and  'b : null 
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
 
-        static member Bind3 : ('a * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : (System.Nullable<'a> * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null 
+                and  'c : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null 
+                and  'c : null
+
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null
+                and  'c : null 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : (System.Nullable<'a> * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : (new : unit -> 'a) and 'a : struct and 'a :> System.ValueType
+                and  'b : null
+                and  'c : null 
+                and  'd : null
+
+        static member Bind3 : ('a * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+
+        static member Bind3 : ('a * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+
+        static member Bind3 : ('a * 'b option * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * 'b option * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'd : null
+
+        static member Bind3 : ('a * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+
+        static member Bind3 : ('a * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+
+        static member Bind3 : ('a * 'b option * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * 'b option * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'd : null
+
+        static member Bind3 : ('a * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * 'b option * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : null
+
+        static member Bind3 : ('a * 'b option * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'c : null
+
+        static member Bind3 : ('a * 'b option * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'c : null
+
+        static member Bind3 : ('a * 'b option * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'c : null 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * 'b option * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'c : null 
+                and  'd : null
+
+        static member Bind3 : ('a * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+
+        static member Bind3 : ('a * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+
+        static member Bind3 : ('a * 'b voption * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * 'b voption * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'd : null
+
+        static member Bind3 : ('a * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+
+        static member Bind3 : ('a * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+
+        static member Bind3 : ('a * 'b voption * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * 'b voption * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'd : null
+
+        static member Bind3 : ('a * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * 'b voption * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : null
+
+        static member Bind3 : ('a * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'c : null
+
+        static member Bind3 : ('a * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'c : null
+
+        static member Bind3 : ('a * 'b voption * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'c : null 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * 'b voption * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'c : null 
+                and  'd : null
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'd : null
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'd : null
+
+        static member Bind3 : ('a * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * System.Nullable<'b> * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
+                and  'd : null
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'c : null
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType 
+                and  'c : null
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : null 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * System.Nullable<'b> * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'b : (new : unit -> 'b) and 'b : struct and 'b :> System.ValueType
+                and  'c : null 
+                and  'd : null
+
+        static member Bind3 : ('a * 'b * 'c option) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'b : null
+
+        static member Bind3 : ('a * 'b * 'c option) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'b : null
+
+        static member Bind3 : ('a * 'b * 'c option) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'b : null 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * 'b * 'c option) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'b : null 
+                and  'd : null
+
+        static member Bind3 : ('a * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'b : null
+
+        static member Bind3 : ('a * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'b : null
+
+        static member Bind3 : ('a * 'b * 'c voption) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
+                when 'a : null
+                and  'b : null 
+                and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
+
+        static member Bind3 : ('a * 'b * 'c voption) * ('a -> 'b -> 'c -> 'd) -> 'd voption
+                when 'a : null
+                and  'b : null 
+                and  'd : null
+
+        static member Bind3 : ('a * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
+                when 'a : null
+                and  'b : null 
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'b : null 
+                and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType
+
+        static member Bind3 : ('a * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'a : null
                 and  'b : null
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a * 'b * System.Nullable<'c>) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
                 and  'b : null
                 and  'c : (new : unit -> 'c) and 'c : struct and 'c :> System.ValueType 
                 and  'd : null
 
-        static member Bind3 : ('a * 'b * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd option
+        static member Bind3 : ('a * 'b * 'c) * ('a -> 'b -> 'c -> 'd option) -> 'd voption
                 when 'a : null
                 and  'b : null 
                 and  'c : null
 
-        static member Bind3 : ('a * 'b * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd option
+        static member Bind3 : ('a * 'b * 'c) * ('a -> 'b -> 'c -> 'd voption) -> 'd voption
+                when 'a : null
+                and  'b : null 
+                and  'c : null
+
+        static member Bind3 : ('a * 'b * 'c) * ('a -> 'b -> 'c -> System.Nullable<'d>) -> 'd voption
                 when 'a : null
                 and  'b : null
                 and  'c : null 
                 and  'd : (new : unit -> 'd) and 'd : struct and 'd :> System.ValueType
 
-        static member Bind3 : ('a * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd option
+        static member Bind3 : ('a * 'b * 'c) * ('a -> 'b -> 'c -> 'd) -> 'd voption
                 when 'a : null
                 and  'b : null
                 and  'c : null 

--- a/tests/FSharp.Interop.NullOptAble.Tests/Operators.fs
+++ b/tests/FSharp.Interop.NullOptAble.Tests/Operators.fs
@@ -94,7 +94,7 @@ let ``Basic Pipe Option None`` () =
     let x = None
     x
      |>?@ (+) 3
-     |> should equal None
+     |> should equal ValueOption<int>.VNone
 [<Fact>]
 let ``Basic Pipe Option None Don't Runn`` () =
     let x = None
@@ -114,7 +114,7 @@ let ``Basic Pipe Nullable Null`` () =
     let x = Nullable()
     x
      |>?@ (+) 3
-     |> should equal None
+     |> should equal ValueOption<int>.VNone
 
 [<Fact>]
 let ``Basic Pipe Null ref Unwrap`` () =
@@ -128,7 +128,7 @@ let ``Basic Pipe Null ref Null`` () =
     let x = null
     x
      |>?@ (+) "Hello"
-     |> should equal VNone
+     |> should equal ValueOption<string>.VNone
 
 [<Fact>]
 let ``Basic Pipe Null ref Unwrap left pipe`` () =
@@ -140,7 +140,7 @@ let ``Basic Pipe Null ref Unwrap left pipe`` () =
 let ``Basic Pipe Null ref Null left pipe`` () =
     let x = null
     (+) "Hello" @?<| x
-     |> should equal VNone
+     |> should equal ValueOption<string>.VNone
 
 [<Fact>]
 let ``Basic left pipe bind null`` () =
@@ -181,7 +181,7 @@ let ``Safe Navigation Operator Example`` ()=
             |>? navChild
             |>? navChild
             |>? navChild
-    result |> should equal VNone
+    result |> should equal ValueOption<Node>.VNone
 
 [<Fact>]
 let ``Safe Navigation Operator Example found`` ()=
@@ -193,9 +193,9 @@ let ``Safe Navigation Operator Example found`` ()=
             |>? navChild
             |>? navChild
             |>? navChild
-    result |> should not' (equal VNone)
+    result |> should not' (equal ValueOption<Node>.VNone)
     result |>?@ should not' (equal null) |> ignore
-    result |>? navChild |> should equal VNone
+    result |>? navChild |> should equal ValueOption<Node>.VNone
 
 
 [<Fact>]
@@ -207,7 +207,7 @@ let ``Basic map homegenous ||>`` () =
 
     (Some("nope"),y) 
         ||>? Map.tryFind
-        |> should equal VNone 
+        |> should equal ValueOption<string>.VNone 
 
 [<Fact>]
 let ``Basic map heterogenous ||>`` () =
@@ -218,7 +218,7 @@ let ``Basic map heterogenous ||>`` () =
 
     ("nope",y) 
         ||>? Map.tryFind
-        |> should equal None 
+        |> should equal ValueOption<string>.VNone 
 
 [<Fact>]
 let ``Basic nullable math heterogenous`` () =

--- a/tests/FSharp.Interop.NullOptAble.Tests/Operators.fs
+++ b/tests/FSharp.Interop.NullOptAble.Tests/Operators.fs
@@ -4,6 +4,7 @@ open System
 open Xunit
 open FsUnit.Xunit
 open FSharp.Interop.NullOptAble.Operators
+open FSharp.Interop.NullOptAble.Experimental
 
 [<Fact>]
 let ``Basic Nulled Nullable`` () =
@@ -106,7 +107,7 @@ let ``Basic Pipe Nullable Unwrap`` () =
     let x = Nullable(3)
     x 
      |>?@ (+) 3
-     |> should equal (Some 6)
+     |> should equal (VSome 6)
 
 [<Fact>]
 let ``Basic Pipe Nullable Null`` () =
@@ -120,52 +121,50 @@ let ``Basic Pipe Null ref Unwrap`` () =
     let x = " World"
     x 
      |>?@ (+) "Hello"
-     |> should equal (Some "Hello World")
+     |> should equal (VSome "Hello World")
 
 [<Fact>]
 let ``Basic Pipe Null ref Null`` () =
     let x = null
     x
      |>?@ (+) "Hello"
-     |> should equal None
+     |> should equal VNone
 
 [<Fact>]
 let ``Basic Pipe Null ref Unwrap left pipe`` () =
     let x = " World"
     (+) "Hello" @?<| x
-     |> should equal (Some "Hello World")
+     |> should equal (VSome "Hello World")
 
 [<Fact>]
 let ``Basic Pipe Null ref Null left pipe`` () =
     let x = null
     (+) "Hello" @?<| x
-     |> should equal None
+     |> should equal VNone
 
 [<Fact>]
 let ``Basic left pipe bind null`` () =
     let x = null
-    Some ?<| x
-     |> should equal None
-    Some @?<| x
-     |> should equal None
+    VSome ?<| x
+     |> should equal VNone
     id @?<| x
-     |> should equal None
+     |> should equal VNone
 [<Fact>]
 let ``Basic left pipe bind`` () =
     let x = "Hello"
     Some ?<| x
-     |> should equal (Some "Hello")
+     |> should equal (VSome "Hello")
     Some @?<| x
-     |> should equal (Some (Some "Hello"))
+     |> should equal (VSome (Some "Hello"))
     id @?<| x
-     |> should equal (Some "Hello")
+     |> should equal (VSome "Hello")
 
 [<Fact>]
 let ``Basic nullable math (terrible)`` () =
     let x = Nullable(3)
     let y = Nullable(3)
     x |>? (fun x'-> y |>?@ (+) x')
-    |> should equal (Some 6)
+    |> should equal (VSome 6)
 
 [<AllowNullLiteral>]
 type Node (child:Node)=
@@ -182,7 +181,7 @@ let ``Safe Navigation Operator Example`` ()=
             |>? navChild
             |>? navChild
             |>? navChild
-    result |> should equal None
+    result |> should equal VNone
 
 [<Fact>]
 let ``Safe Navigation Operator Example found`` ()=
@@ -194,9 +193,9 @@ let ``Safe Navigation Operator Example found`` ()=
             |>? navChild
             |>? navChild
             |>? navChild
-    result |> should not' (equal None)
+    result |> should not' (equal VNone)
     result |>?@ should not' (equal null) |> ignore
-    result |>? navChild |> should equal None
+    result |>? navChild |> should equal VNone
 
 
 [<Fact>]
@@ -204,18 +203,18 @@ let ``Basic map homegenous ||>`` () =
     let y = Some <| Map.ofList [("Here", "Hello World")]
     let x = Some "Here"
     (x,y) ||>? Map.tryFind
-          |> should equal (Some "Hello World")
+          |> should equal (VSome "Hello World")
 
     (Some("nope"),y) 
         ||>? Map.tryFind
-        |> should equal None 
+        |> should equal VNone 
 
 [<Fact>]
 let ``Basic map heterogenous ||>`` () =
     let y = Some <| Map.ofList [("Here", "Hello World")]
     let x = "Here"
     (x,y) ||>? Map.tryFind
-          |> should equal (Some "Hello World")
+          |> should equal (VSome "Hello World")
 
     ("nope",y) 
         ||>? Map.tryFind
@@ -226,4 +225,4 @@ let ``Basic nullable math heterogenous`` () =
     let x = Nullable(3)
     let y = Some(3)
     (x,y) ||>?@ ( + )
-          |> should equal (Some 6)
+          |> should equal (VSome 6)

--- a/tests/FSharp.Interop.NullOptAble.Tests/RealWorld.fs
+++ b/tests/FSharp.Interop.NullOptAble.Tests/RealWorld.fs
@@ -43,7 +43,7 @@ let ``Safe Navigation Operator Example`` ()=
         let! b = a.child
         let! c = b.child
         return c
-    } |> should equal VNone
+    } |> should equal ValueOption<Node>.VNone
     
 [<Fact>] 
 let ``Safe Navigation Operator Seq Example`` ()=

--- a/tests/FSharp.Interop.NullOptAble.Tests/RealWorld.fs
+++ b/tests/FSharp.Interop.NullOptAble.Tests/RealWorld.fs
@@ -6,6 +6,7 @@ Real World-ish examples
 module RealWorldTests
 open System
 open System.Text
+open FSharp.Interop.NullOptAble.Experimental
 open FSharp.Interop.NullOptAble
 (*** hide ***)
 open Xunit
@@ -17,11 +18,11 @@ open FsUnit.Xunit
 let ``Basic nullable math`` () =
     let x = Nullable(3)
     let y = Nullable(3)
-    option {
+    voption {
         let! x' = x
         let! y' = y
         return (x' + y')
-    } |> should equal (Some 6)
+    } |> should equal (VSome 6)
 
 (*** hide ***)
 [<AllowNullLiteral>]
@@ -37,12 +38,12 @@ Doing the things found in this [MSDN Blog Post did with the Safe Nav operator](h
 let ``Safe Navigation Operator Example`` ()=
     
     let parent = Node()
-    option {
+    voption {
         let! a = parent.child
         let! b = a.child
         let! c = b.child
         return c
-    } |> should equal None
+    } |> should equal VNone
     
 [<Fact>] 
 let ``Safe Navigation Operator Seq Example`` ()=
@@ -69,7 +70,7 @@ let ``IsPrime Example`` ()=
     let isprime n =
         let rec check i =
             n <> 1 && (i > n/2 || (n % i <> 0 && check (i + 1)))
-        if check 2 then Some n else None
+        if check 2 then VSome n else VNone
 
     let prime = chooseSeq { for n in 1..100 do 
                                 let! p = isprime n
@@ -85,9 +86,9 @@ Solution using `option {}` for this [RNA Transcription problem from exercism](ht
 *)
 [<Fact>]
 let ``RNA transcriptions `` () =
-    let toRna (dna: string): string option = 
-        let combine (sb:StringBuilder option) =
-            let append (c:char) = option {
+    let toRna (dna: string): string voption = 
+        let combine (sb:StringBuilder voption) =
+            let append (c:char) = voption {
                     let! sb' = sb
                     return sb'.Append(c)
                 }
@@ -96,15 +97,15 @@ let ``RNA transcriptions `` () =
             | 'C' -> 'G' |> append
             | 'T' -> 'A' |> append
             | 'A' -> 'U' |> append
-            | ___ -> None
-        option {
+            | ___ -> VNone
+        voption {
             let! dna' = dna //handles if string is null
-            let! sb' = dna' |> Seq.fold combine (Some <| StringBuilder())
+            let! sb' = dna' |> Seq.fold combine (VSome <| StringBuilder())
             return sb'.ToString()
         }
         
     //test case from exercism
-    toRna "ACGTGGTCTTAA" |> should equal (Some "UGCACCAGAAUU")
+    toRna "ACGTGGTCTTAA" |> should equal (VSome "UGCACCAGAAUU")
 
 (** 
 Solution using `chooseSeq {}` for this [Rain Drops (Fizz buzz) problem from exercism](http://exercism.io/exercises/fsharp/raindrops/readme).

--- a/tests/FSharp.Interop.NullOptAble.Tests/RealWorldOperators.fs
+++ b/tests/FSharp.Interop.NullOptAble.Tests/RealWorldOperators.fs
@@ -7,6 +7,7 @@ module RealWorldOperatorsTests
 open System
 open System.Text
 open FSharp.Interop.NullOptAble.Operators
+open FSharp.Interop.NullOptAble.Experimental
 (*** hide ***)
 open Xunit
 open FsUnit.Xunit
@@ -30,7 +31,7 @@ However I suggest using [computational expressions](https://ekonbenefits.github.
 let ``Basic concat`` () =
     let x = "Hello "
     let y = "World"
-    (x,y) ||>? ( + ) |> should equal (Some "Hello World")
+    (x,y) ||>? ( + ) |> should equal (VSome "Hello World")
 [<Fact>]
 let ``Basic concat none`` () =
     let x = "Hello "
@@ -44,7 +45,7 @@ Binding doesn't work if function returns a non-`_:null or Nullable<_> or Option<
 let ``Basic nullable math`` () =
     let x = Nullable(3)
     let y = Nullable(3)
-    (x,y) ||>?@ ( + ) |> should equal (Some 6)
+    (x,y) ||>?@ ( + ) |> should equal (VSome 6)
 
 (*** hide ***)
 [<AllowNullLiteral>]
@@ -65,7 +66,7 @@ let ``Safe Navigation Operator Example`` ()=
         |>? getChild 
         |>? getChild
         |>? getChild
-        |> should equal None
+        |> should equal VNone
 
 [<Fact>] 
 let ``Safe Navigation Operator Seq Example`` ()=
@@ -83,7 +84,7 @@ let ``Safe Navigation Operator Seq Example`` ()=
                 |>? getChild
                 |>? getChild
     } 
-        |> Seq.choose id
+        |> Seq.choose Option.ofValueOption
         |> Seq.length |> should equal 1
 
 
@@ -94,8 +95,8 @@ Solution using `|>?` for this [RNA Transcription problem from exercism](http://e
 *)
 [<Fact>]
 let ``RNA transcriptions `` () =
-    let toRna (dna: string): string option = 
-        let combine (sb:StringBuilder option) =
+    let toRna (dna: string): string voption = 
+        let combine (sb:StringBuilder voption) =
             let append (c:char) = 
                 sb |>? (fun (s:StringBuilder) -> s.Append(c))       
             function
@@ -103,10 +104,10 @@ let ``RNA transcriptions `` () =
             | 'C' -> 'G' |> append
             | 'T' -> 'A' |> append
             | 'A' -> 'U' |> append
-            | ___ -> None
+            | ___ -> VNone
         dna
-           |>? Seq.fold combine (Some <| StringBuilder())
+           |>? Seq.fold combine (VSome <| StringBuilder())
            |>? string
 
     //test case from exercism
-    toRna "ACGTGGTCTTAA" |> should equal (Some "UGCACCAGAAUU")
+    toRna "ACGTGGTCTTAA" |> should equal (VSome "UGCACCAGAAUU")

--- a/tests/FSharp.Interop.NullOptAble.Tests/RealWorldOperators.fs
+++ b/tests/FSharp.Interop.NullOptAble.Tests/RealWorldOperators.fs
@@ -36,7 +36,7 @@ let ``Basic concat`` () =
 let ``Basic concat none`` () =
     let x = "Hello "
     let y:string = null
-    (x,y) ||>? ( + ) |> should equal (None)
+    (x,y) ||>? ( + ) |> should equal (ValueOption<string>.VNone)
 
 (**
 Binding doesn't work if function returns a non-`_:null or Nullable<_> or Option<_>`. You can use map operator instead `|>?@` but becareful don't use it on something that could be null.
@@ -66,7 +66,7 @@ let ``Safe Navigation Operator Example`` ()=
         |>? getChild 
         |>? getChild
         |>? getChild
-        |> should equal VNone
+        |> should equal ValueOption<Node>.VNone
 
 [<Fact>] 
 let ``Safe Navigation Operator Seq Example`` ()=


### PR DESCRIPTION
There was some suggestion in this discussion https://github.com/fsharp/fslang-design/issues/230 that struct version of option might be ideal default usage version the normal reference option. 

So i thought I'd try adding a version to the project and see what the resulting code looked like. 

It end up pretty gross, and FSUnit should equal just isn't going to work easily with VNone because it boxes and loses type inference.  

So I think whenever this shows up in F# core, I'll just add it as another type to convert to a reference style option before binding or mapping.

This branch was just for experimentation.